### PR TITLE
Removed calling next() function

### DIFF
--- a/lib/pong.js
+++ b/lib/pong.js
@@ -1,18 +1,17 @@
 'use strict';
 
 /**
-* FUNCTION: pong( request, response, next )
+* FUNCTION: pong( request, response )
 *	Returns a `pong` response.
 *
 * @param {Object} request - HTTP request object
 * @param {Object} response - HTTP response object
 * @param {Function} next - callback to invoke after sending response
 */
-function pong( request, response, next ) {
+function pong( request, response ) {
 	response
 		.status( 200 )
 		.send( 'pong' );
-	next();
 } // end FUNCTION pong()
 
 

--- a/test/test.pong.js
+++ b/test/test.pong.js
@@ -7,7 +7,6 @@ var mpath = './../lib/pong.js';
 // MODULES //
 
 var chai = require( 'chai' ),
-	noop = require( '@kgryte/noop' ),
 	pong = require( mpath );
 
 
@@ -48,12 +47,12 @@ describe( 'pong', function tests() {
 	});
 
 	it( 'should return a 200 status', function test() {
-		pong( request, response, noop );
+		pong( request, response );
 		assert.strictEqual( response._status, 200 );
 	});
 
 	it( 'should return a response body which is a string reading `pong`', function test() {
-		pong( request, response, noop );
+		pong( request, response );
 		assert.strictEqual( response._body, 'pong' );
 	});
 

--- a/test/test.pong.js
+++ b/test/test.pong.js
@@ -57,12 +57,4 @@ describe( 'pong', function tests() {
 		assert.strictEqual( response._body, 'pong' );
 	});
 
-	it( 'should invoke a callback after sending the response', function test( done ) {
-		pong( request, response, next );
-		function next() {
-			assert.ok( true );
-			done();
-		}
-	});
-
 });


### PR DESCRIPTION
Yo,

I have an issue where the calling of next() after sending pong crashes my service. The next() causes the my 404 handler function (default generated by express generator) to be invoked which ultimately tries to start rendering a page, but as res.end() as already been called (as part of send) it errors and kills the service.

So with this pull request I'm recommending removing the call to next, which should be OK since the response has already ended. Also I don't think anyone using this module would want it to call other middleware since presumably they're using it as a healthcheck end point, mutually exclusive from the rest of their app.

What do you think?
